### PR TITLE
Add GitHub Pages fallback for token path URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="apple-mobile-web-app-capable" content="no">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="HomePage">
+  <link rel="icon"
+    href="data:image/svg+xml, <svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22> <text y=%22.9em%22 font-size=%2290%22> 🧭 </text> </svg>">
+  <link rel="apple-touch-icon"
+    href="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/iOS/ios15-safari-icon.png">
+  <title>HomePage</title>
+  <link href="./CSS/style.css" rel="stylesheet">
+  <link href="./CSS/card.css" rel="stylesheet">
+  <link href="./CSS/grid.css" rel="stylesheet">
+  <link href="./CSS/header.css" rel="stylesheet">
+  <link href="./CSS/toggle.css" rel="stylesheet">
+  <link href="./CSS/colors.css" rel="stylesheet">
+  <script src="https://kit.fontawesome.com/5e8187de28.js" crossorigin="anonymous"></script>
+</head>
+
+<body>
+
+  <header>
+    <div style="display:flex; align-items:center;">
+    <a href="https://app.raindrop.io/my/0/">
+    <img src="https://miro.medium.com/max/1024/1*JtxOMEcB0N7yoGiHjFf1Gg.png"
+    height="30px" width="30px" style="margin:0 10px;"></a>
+    <h1>Favorites</h1></div>
+    <div style="display:flex; align-items:center;">
+      <i class="fa-solid fa-star" style="font-size: 20px; margin-right:6px; color:#707070;"></i>
+      <input type="checkbox" id="switch" /><label for="switch">Toggle</label>
+      <i class="fa-regular fa-image" style="font-size: 20px; margin-left:15px; color:#707070; margin-right: 10px;"></i>
+    </div>
+  </header>
+
+  <div id="grid"></div>
+
+  <script type="text/javascript" src="./token.js"></script>
+  <script type="text/javascript" src="./JS/favicons.js"></script>
+  <script type="text/javascript" src="./JS/inserthtml.js"></script>
+  <script type="text/javascript" src="./JS/fetch.js"></script>
+  <script type="text/javascript" src="./JS/toggle.js"></script>
+  <script> getGrid() </script>
+
+</body>
+</html>

--- a/token.js
+++ b/token.js
@@ -1,22 +1,34 @@
 // 💧 Enter Your Raindrop Token here 👇 //
 let raindropToken = "XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX";
 
+const findTokenInPath = () => {
+  const pathSegments = window.location.pathname.split("/").filter(Boolean);
+  if (!pathSegments.length) return null;
+
+  const candidate = decodeURIComponent(pathSegments[pathSegments.length - 1]);
+  const looksLikeToken = /^[A-Za-z0-9_-]{30,}$/.test(candidate);
+
+  return looksLikeToken ? candidate : null;
+};
+
+const urlToken = findTokenInPath();
 let token;
 
-if (raindropToken == "XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX") {
-  if (
-    localStorage.token == "null" ||
-    localStorage.token == "undefined" ||
-    localStorage.token == undefined
-  ) {
-    const localToken = prompt(
-      "🏠 Welcome to Raindrop HomePage\n\nplease enter your test-token\nif you dont know how to do it, please visit the url below\n\nℹ️ https://github.com/Virgile-fr/Raindrop-HomePage"
-    );
-    localStorage.setItem("token", localToken);
-    token = localStorage.token;
-  } else {
-    token = localStorage.token;
-  }
-} else {
+if (urlToken) {
+  localStorage.setItem("token", urlToken);
+  token = urlToken;
+} else if (raindropToken !== "XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX-XXXXXXX") {
   token = raindropToken;
+} else if (
+  localStorage.token == "null" ||
+  localStorage.token == "undefined" ||
+  localStorage.token == undefined
+) {
+  const localToken = prompt(
+    "🏠 Welcome to Raindrop HomePage\n\nplease enter your test-token\nif you dont know how to do it, please visit the url below\n\nℹ️ https://github.com/Virgile-fr/Raindrop-HomePage"
+  );
+  localStorage.setItem("token", localToken);
+  token = localStorage.token;
+} else {
+  token = localStorage.token;
 }


### PR DESCRIPTION
## Summary
- add 404 fallback page mirroring the index to support GitHub Pages direct path access
- allow token-in-path URLs to load without 404 responses on GitHub Pages

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939924d8b40832584df0c9536098011)