### PR TITLE
Add usage-based sorting for favorites

### DIFF
--- a/JS/fetch.js
+++ b/JS/fetch.js
@@ -1,3 +1,5 @@
+const USAGE_STORAGE_KEY = "favoriteUsageCounts";
+
 function fetchcollections() {
   fetch("https://api.raindrop.io/rest/v1/collections", {
     method: "GET",
@@ -20,6 +22,29 @@ function fetchcollection(collectionID) {
     });
 }
 
+function getUsageCount(link) {
+  const usageData = JSON.parse(localStorage.getItem(USAGE_STORAGE_KEY) || "{}");
+  return usageData[link] || 0;
+}
+
+function recordUsage(link) {
+  const usageData = JSON.parse(localStorage.getItem(USAGE_STORAGE_KEY) || "{}");
+  usageData[link] = (usageData[link] || 0) + 1;
+  localStorage.setItem(USAGE_STORAGE_KEY, JSON.stringify(usageData));
+}
+
+function sortByUsage(items) {
+  return [...items].sort((a, b) => {
+    const usageDifference = getUsageCount(b.link) - getUsageCount(a.link);
+
+    if (usageDifference !== 0) {
+      return usageDifference;
+    }
+
+    return new Date(b.created).getTime() - new Date(a.created).getTime();
+  });
+}
+
 function fetchCardsIcons() {
   fetch("https://api.raindrop.io/rest/v1/raindrops/0?search=❤️&perpage=50", {
     method: "GET",
@@ -27,8 +52,7 @@ function fetchCardsIcons() {
   })
     .then((response) => response.json())
     .then((data) => {
-      // reorgnise data by creation date (most recent first)
-      const sortedItems = data.items.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
+      const sortedItems = sortByUsage(data.items);
 
       sortedItems.forEach((result) => {
         let content = test(result.link, result.title);
@@ -46,8 +70,7 @@ function fetchCardsCovers() {
   })
     .then((response) => response.json())
     .then((data) => {
-      // reorgnise data by creation date (most recent first)
-      const sortedItems = data.items.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
+      const sortedItems = sortByUsage(data.items);
 
       sortedItems.forEach((result) => {
         let content = test2(result.link, result.title, result.cover);

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -1,5 +1,7 @@
 let grid = document.getElementById("grid");
 
+grid.addEventListener("click", handleCardClick);
+
 function smallerTitle(title) {
   if (title.length > 14) {
     return title.substring(0, 12) + "..";
@@ -31,4 +33,18 @@ function test2(lien, titre, image) {
     </div>
   </a>`;
   return content;
+}
+
+function handleCardClick(event) {
+  const anchor = event.target.closest("a");
+
+  if (!anchor || !grid.contains(anchor)) {
+    return;
+  }
+
+  const link = anchor.getAttribute("href");
+
+  if (link) {
+    recordUsage(link);
+  }
 }


### PR DESCRIPTION
## Summary
- track favorite usage counts locally to inform ordering
- record favorite clicks and sort fetched items by usage frequency with recency as a tiebreaker

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d39d88f288325bd4377909ddd5a38)