### PR TITLE
Improve favorites fetching performance

### DIFF
--- a/JS/fetch.js
+++ b/JS/fetch.js
@@ -1,25 +1,33 @@
 const USAGE_STORAGE_KEY = "favoriteUsageCounts";
+const FAVORITES_PER_PAGE = 50;
+const MAX_FAVORITE_PAGES = 2;
+const FAVORITE_QUERY = encodeURIComponent("❤️");
 
-function fetchcollections() {
-  fetch("https://api.raindrop.io/rest/v1/collections", {
+async function fetchJson(url) {
+  const response = await fetch(url, {
     method: "GET",
     headers: { Authorization: "Bearer " + token },
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      console.log(data);
-    });
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+
+  return response.json();
 }
 
-function fetchcollection(collectionID) {
-  fetch("https://api.raindrop.io/rest/v1/raindrops/" + collectionID, {
-    method: "GET",
-    headers: { Authorization: "Bearer " + token },
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      console.log(data);
-    });
+async function fetchcollections() {
+  const data = await fetchJson("https://api.raindrop.io/rest/v1/collections");
+  console.log(data);
+  return data;
+}
+
+async function fetchcollection(collectionID) {
+  const data = await fetchJson(
+    "https://api.raindrop.io/rest/v1/raindrops/" + collectionID
+  );
+  console.log(data);
+  return data;
 }
 
 function getUsageCount(link) {
@@ -45,38 +53,51 @@ function sortByUsage(items) {
   });
 }
 
+function getTotalPages(meta) {
+  const totalItems = meta?.count ?? meta?.items?.length ?? 0;
+  const pageCount = Math.ceil(totalItems / FAVORITES_PER_PAGE);
+  return Math.min(Math.max(pageCount, 1), MAX_FAVORITE_PAGES);
+}
+
+async function fetchFavoritePage(page) {
+  return fetchJson(
+    `https://api.raindrop.io/rest/v1/raindrops/0?search=${FAVORITE_QUERY}&perpage=${FAVORITES_PER_PAGE}&page=${page}`
+  );
+}
+
+async function fetchAllFavoriteItems() {
+  const firstPage = await fetchFavoritePage(0);
+  const totalPages = getTotalPages(firstPage);
+
+  if (totalPages === 1) {
+    return firstPage.items ?? [];
+  }
+
+  const additionalPages = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, index) => fetchFavoritePage(index + 1))
+  );
+
+  return [firstPage, ...additionalPages].flatMap((page) => page.items ?? []);
+}
+
+async function renderFavoriteCards(renderer) {
+  try {
+    const favoriteItems = await fetchAllFavoriteItems();
+    const sortedItems = sortByUsage(favoriteItems);
+    const content = sortedItems.map(renderer).join("");
+
+    grid.insertAdjacentHTML("beforeend", content);
+  } catch (error) {
+    console.error("Failed to render favorites", error);
+  }
+}
+
 function fetchCardsIcons() {
-  fetch("https://api.raindrop.io/rest/v1/raindrops/0?search=❤️&perpage=50", {
-    method: "GET",
-    headers: { Authorization: "Bearer " + token },
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      const sortedItems = sortByUsage(data.items);
-
-      sortedItems.forEach((result) => {
-        let content = test(result.link, result.title);
-
-        grid.insertAdjacentHTML("beforeend", content);
-      });
-    });
-} 
-
+  renderFavoriteCards((result) => test(result.link, result.title));
+}
 
 function fetchCardsCovers() {
-  fetch("https://api.raindrop.io/rest/v1/raindrops/0?search=❤️&perpage=50", {
-    method: "GET",
-    headers: { Authorization: "Bearer " + token },
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      const sortedItems = sortByUsage(data.items);
-
-      sortedItems.forEach((result) => {
-        let content = test2(result.link, result.title, result.cover);
-        grid.insertAdjacentHTML("beforeend", content);
-      });
-    });
+  renderFavoriteCards((result) => test2(result.link, result.title, result.cover));
 }
 
 // result.cover = preview in raindrop


### PR DESCRIPTION
## Summary
- refactor fetch helpers to use async/await and shared request handling
- add pagination support to load up to two pages of favorite raindrops
- render cards in bulk after sorting for smoother loading and usage tracking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d40d1b3bc8325a86fdb2edfcbdced)