### PR TITLE
Use Vemetric favicon API by default with Google fallback

### DIFF
--- a/JS/favicons.js
+++ b/JS/favicons.js
@@ -17,6 +17,13 @@ function googlefavicon(adress) {
     splitadress);
 }
 
+function vemetricfavicon(adress) {
+  let splitadress = adress.split("/");
+  splitadress = splitadress.slice(2, 3);
+  splitadress = splitadress.join("/");
+  return (newadress = `https://favicon-api.vemetric.com/v1/?domain=${splitadress}`);
+}
+
 function duckduckgofavicon(adress) {
   let splitadress = adress.split("/");
   splitadress = splitadress.slice(2, 3);

--- a/JS/fetch.js
+++ b/JS/fetch.js
@@ -103,6 +103,7 @@ function fetchCardsCovers() {
 // result.cover = preview in raindrop
 // result.link = url of the link
 // result.title = name of the link
+// ${vemetricfavicon(result.link)} = Vemetric Favicon API icon of the link
 // ${googlefavicon(result.link)} = google favicon of the link
 // ${favicon(result.link)} = favicon of the link
 // ${statvoofavicon(result.link)} = statvoofavicon favicon of the link

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -9,12 +9,14 @@ function smallerTitle(title) {
 }
 
 function test(lien, titre) {
+  const vemetricIcon = vemetricfavicon(lien);
+  const googleIcon = googlefavicon(lien);
   let content = `
   <a href="${lien}" target="_blank">
     <div class="card icon-cards">
       <!-- this line is for filter icon : <div class="image" style="background-image:url(${googlefavicon(lien)});"> -->
       <div class="filter">
-          <img class="icon" src=${googlefavicon(lien)}>
+          <img class="icon" src="${vemetricIcon}" onerror="this.onerror=null; this.src='${googleIcon}'">
         </div>
         <!--  this line is for filter icon : </div> -->
         <div class="title" title="${titre}">${smallerTitle(titre)}</div>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Raindrop Homepage offers two display modes that you can toggle using the switch 
 
 ### 🌐 Favicon view
 
-* Icons are fetched using the **Google Icons API**, which is one of the best free options available.
+* Icons are fetched using the **Vemetric Favicon API** by default, with the **Google Icons API** kept as a fallback for robustness.
 * Some favicons might still appear in low resolution depending on the site.
 * Each card uses a `backdrop-filter` effect for a frosted glass style background.
 * Technically, it would be possible to fetch `apple-touch-icon` tags from each site, but this is not implemented yet.


### PR DESCRIPTION
## Summary
- add Vemetric favicon API helper and use it as the default icon fetcher with Google fallback
- document the new default favicon source
- update usage comments for favicon helpers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d44dedc208325b09f7524aff06df3)