### PR TITLE
Fix Vemetric favicon URL

### DIFF
--- a/JS/favicons.js
+++ b/JS/favicons.js
@@ -29,14 +29,7 @@ function vemetricfavicon(adress) {
   const domain = extractDomain(adress);
   if (!domain) return null;
 
-  return `https://favicon-api.vemetric.com/v1/?domain=${encodeURIComponent(domain)}`;
-}
-
-function vemetricfavicon(adress) {
-  let splitadress = adress.split("/");
-  splitadress = splitadress.slice(2, 3);
-  splitadress = splitadress.join("/");
-  return (newadress = `https://favicon-api.vemetric.com/v1/?domain=${splitadress}`);
+  return `https://favicon.vemetric.com/${encodeURIComponent(domain)}`;
 }
 
 function duckduckgofavicon(adress) {


### PR DESCRIPTION
## Summary
- update Vemetric favicon helper to use the new favicon.vemetric.com endpoint
- remove duplicate helper implementation

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d48b5b13083259768a2ecfa734bbd)