### PR TITLE
Apply dominant icon colors to filter backgrounds

### DIFF
--- a/JS/dominant-color.js
+++ b/JS/dominant-color.js
@@ -1,0 +1,50 @@
+function computeDominantColor(image) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+
+  const context = canvas.getContext("2d");
+  if (!context) return null;
+
+  context.drawImage(image, 0, 0, 1, 1);
+  const [r, g, b] = context.getImageData(0, 0, 1, 1).data;
+
+  return { r, g, b };
+}
+
+function applyFilterBackground(filter, color) {
+  const darkened = {
+    r: Math.round(color.r * 0.9),
+    g: Math.round(color.g * 0.9),
+    b: Math.round(color.b * 0.9),
+  };
+
+  filter.style.background = `linear-gradient(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.12)), rgb(${darkened.r}, ${darkened.g}, ${darkened.b})`;
+}
+
+function colorizeIconBackground(icon) {
+  if (icon.dataset.colorized) return;
+
+  const filter = icon.closest(".filter");
+  if (!filter) return;
+
+  const color = computeDominantColor(icon);
+  if (!color) return;
+
+  applyFilterBackground(filter, color);
+  icon.dataset.colorized = "true";
+}
+
+function refreshIconFilterColors() {
+  const icons = document.querySelectorAll("img.icon");
+
+  icons.forEach((icon) => {
+    const applyColor = () => colorizeIconBackground(icon);
+
+    if (icon.complete && icon.naturalWidth > 0) {
+      applyColor();
+    } else {
+      icon.addEventListener("load", applyColor, { once: true });
+    }
+  });
+}

--- a/JS/fetch.js
+++ b/JS/fetch.js
@@ -87,6 +87,7 @@ async function renderFavoriteCards(renderer) {
     const content = sortedItems.map(renderer).join("");
 
     grid.insertAdjacentHTML("beforeend", content);
+    refreshIconFilterColors();
   } catch (error) {
     console.error("Failed to render favorites", error);
   }

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -17,7 +17,7 @@ function test(lien, titre) {
     <div class="card icon-cards">
       <!-- this line is for filter icon : <div class="image" style="background-image:url(${googlefavicon(lien)});"> -->
       <div class="filter">
-          <img class="icon" src="${initialIcon}" onerror="this.onerror=null; this.src='${googleIcon ?? ''}'">
+          <img class="icon" src="${initialIcon}" crossOrigin="anonymous" onerror="this.onerror=null; this.src='${googleIcon ?? ''}'">
         </div>
         <!--  this line is for filter icon : </div> -->
         <div class="title" title="${titre}">${smallerTitle(titre)}</div>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
   <script type="text/javascript" src="./token.js"></script>
   <script type="text/javascript" src="./JS/favicons.js"></script>
   <script type="text/javascript" src="./JS/inserthtml.js"></script>
+  <script type="text/javascript" src="./JS/dominant-color.js"></script>
   <script type="text/javascript" src="./JS/fetch.js"></script>
   <script type="text/javascript" src="./JS/toggle.js"></script>
   <script> getGrid() </script>


### PR DESCRIPTION
## Summary
- add client-side dominant color extraction for icons to tint filter backgrounds
- ensure icon requests allow cross-origin canvas access for color sampling
- trigger background updates after rendering cards

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8d14a9088325975ca076dba9351b)