### PR TITLE
Adjust dominant color filter and update 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -42,6 +42,7 @@
   <script type="text/javascript" src="./token.js"></script>
   <script type="text/javascript" src="./JS/favicons.js"></script>
   <script type="text/javascript" src="./JS/inserthtml.js"></script>
+  <script type="text/javascript" src="./JS/dominant-color.js"></script>
   <script type="text/javascript" src="./JS/fetch.js"></script>
   <script type="text/javascript" src="./JS/toggle.js"></script>
   <script> getGrid() </script>

--- a/JS/dominant-color.js
+++ b/JS/dominant-color.js
@@ -13,13 +13,27 @@ function computeDominantColor(image) {
 }
 
 function applyFilterBackground(filter, color) {
-  const darkened = {
-    r: Math.round(color.r * 0.9),
-    g: Math.round(color.g * 0.9),
-    b: Math.round(color.b * 0.9),
-  };
+  const clamp = (value) => Math.min(255, Math.max(0, Math.round(value)));
+  const luminance =
+    (0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b) / 255;
 
-  filter.style.background = `linear-gradient(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.12)), rgb(${darkened.r}, ${darkened.g}, ${darkened.b})`;
+  const isTooDark = luminance < 0.35;
+
+  const adjustedColor = isTooDark
+    ? {
+        r: clamp(color.r + (255 - color.r) * 0.25),
+        g: clamp(color.g + (255 - color.g) * 0.25),
+        b: clamp(color.b + (255 - color.b) * 0.25),
+      }
+    : {
+        r: clamp(color.r * 0.8),
+        g: clamp(color.g * 0.8),
+        b: clamp(color.b * 0.8),
+      };
+
+  const overlayOpacity = isTooDark ? 0.12 : 0.18;
+
+  filter.style.background = `linear-gradient(rgba(0, 0, 0, ${overlayOpacity}), rgba(0, 0, 0, ${overlayOpacity})), rgb(${adjustedColor.r}, ${adjustedColor.g}, ${adjustedColor.b})`;
 }
 
 function colorizeIconBackground(icon) {


### PR DESCRIPTION
## Summary
- adjust dominant color handling to lighten very dark icons and darken brighter ones with a stronger overlay
- clamp computed colors for safer filter backgrounds and refine overlay strength
- align 404.html script list with main page by including dominant color support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d914232a0832585cc4ea00e0f99ed)