### PR TITLE
Add favicon provider toggle and fix domain handling

### DIFF
--- a/CSS/header.css
+++ b/CSS/header.css
@@ -12,3 +12,11 @@ header h1{
   margin-bottom: 0px;
   margin-top: 0px;
 }
+
+.favorite-priority-toggle {
+  cursor: pointer;
+}
+
+.favorite-priority-toggle:hover {
+  color: white;
+}

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -9,15 +9,15 @@ function smallerTitle(title) {
 }
 
 function test(lien, titre) {
-  const vemetricIcon = vemetricfavicon(lien);
-  const googleIcon = googlefavicon(lien);
-  const initialIcon = vemetricIcon ?? googleIcon ?? "";
+  const { primary, fallback } = getFaviconPreference(lien);
+  const initialIcon = primary ?? fallback ?? "";
+  const fallbackIcon = fallback ?? "";
   let content = `
   <a href="${lien}" target="_blank">
     <div class="card icon-cards">
       <!-- this line is for filter icon : <div class="image" style="background-image:url(${googlefavicon(lien)});"> -->
       <div class="filter">
-          <img class="icon" src="${initialIcon}" crossOrigin="anonymous" onerror="this.onerror=null; this.src='${googleIcon ?? ''}'">
+          <img class="icon" src="${initialIcon}" crossOrigin="anonymous" onerror="this.onerror=null; this.src='${fallbackIcon}'">
         </div>
         <!--  this line is for filter icon : </div> -->
         <div class="title" title="${titre}">${smallerTitle(titre)}</div>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     height="30px" width="30px" style="margin:0 10px;"></a>
     <h1>Favorites</h1></div>
     <div style="display:flex; align-items:center;">
-      <i class="fa-solid fa-star" style="font-size: 20px; margin-right:6px; color:#707070;"></i>
+      <i class="fa-solid fa-star favorite-priority-toggle" style="font-size: 20px; margin-right:6px; color:#707070;"></i>
       <input type="checkbox" id="switch" /><label for="switch">Toggle</label>
       <i class="fa-regular fa-image" style="font-size: 20px; margin-left:15px; color:#707070; margin-right: 10px;"></i>
     </div>


### PR DESCRIPTION
## Summary
- fix Google favicon construction to send only the domain/host to the API
- add a star-icon toggle that switches favicon priority between Google and Vemetric with persistence and re-rendering when in icon view
- style the star icon to highlight on hover while keeping the existing iconography

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dac4416348325a55b1dc1ee3d94b6)