### PR TITLE
Handle favicon CORS failures

### DIFF
--- a/JS/dominant-color.js
+++ b/JS/dominant-color.js
@@ -6,10 +6,14 @@ function computeDominantColor(image) {
   const context = canvas.getContext("2d");
   if (!context) return null;
 
-  context.drawImage(image, 0, 0, 1, 1);
-  const [r, g, b] = context.getImageData(0, 0, 1, 1).data;
-
-  return { r, g, b };
+  try {
+    context.drawImage(image, 0, 0, 1, 1);
+    const [r, g, b] = context.getImageData(0, 0, 1, 1).data;
+    return { r, g, b };
+  } catch (error) {
+    console.warn("Unable to compute dominant color", error);
+    return null;
+  }
 }
 
 function applyFilterBackground(filter, color) {

--- a/JS/favicons.js
+++ b/JS/favicons.js
@@ -80,6 +80,18 @@ function getFaviconPreference(address) {
   return { primary: vemetricIcon, fallback: googleIcon };
 }
 
+function allowsCrossOriginLoading(url) {
+  if (!url) return false;
+
+  const blockedHosts = ["www.google.com"];
+  try {
+    const hostname = new URL(url).hostname;
+    return !blockedHosts.includes(hostname);
+  } catch {
+    return false;
+  }
+}
+
 function updateFaviconPriorityIndicator() {
   const toggleIcon = document.querySelector(".favorite-priority-toggle");
 

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -12,12 +12,15 @@ function test(lien, titre) {
   const { primary, fallback } = getFaviconPreference(lien);
   const initialIcon = primary ?? fallback ?? "";
   const fallbackIcon = fallback ?? "";
+  const crossOriginAttr = allowsCrossOriginLoading(initialIcon)
+    ? ' crossOrigin="anonymous"'
+    : "";
   let content = `
   <a href="${lien}" target="_blank">
     <div class="card icon-cards">
       <!-- this line is for filter icon : <div class="image" style="background-image:url(${googlefavicon(lien)});"> -->
       <div class="filter">
-          <img class="icon" src="${initialIcon}" crossOrigin="anonymous" onerror="this.onerror=null; this.src='${fallbackIcon}'">
+          <img class="icon" src="${initialIcon}"${crossOriginAttr} onerror="this.onerror=null; this.src='${fallbackIcon}'">
         </div>
         <!--  this line is for filter icon : </div> -->
         <div class="title" title="${titre}">${smallerTitle(titre)}</div>


### PR DESCRIPTION
## Summary
- avoid requesting Google favicons with CORS to prevent blocked requests
- add defensive dominant-color calculation when icons cannot be read
- adjust icon rendering to skip cross-origin when the provider blocks it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db5c7e62c8325bdb3d04186e4616d)