### PR TITLE
Improve favicon color handling and icon styling

### DIFF
--- a/CSS/card.css
+++ b/CSS/card.css
@@ -46,7 +46,9 @@
   height: var(--icon-size);
   width: var(--icon-size);
   border-radius: var(--icon-radius);
-  filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.1));
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.12));
 }
 
 .filter {
@@ -59,12 +61,15 @@
   border-radius: var(--radius-images);
   overflow: hidden;
   box-sizing: border-box;
-  backdrop-filter: blur(60px) brightness(0.8);
-  -webkit-backdrop-filter: blur(40px);
+  padding: 8px;
+  gap: 6px;
+  backdrop-filter: blur(60px) saturate(1.05) brightness(0.9);
+  -webkit-backdrop-filter: blur(40px) saturate(1.05) brightness(0.9);
   border: var(--image-border-color);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 .card:hover .filter {
-  backdrop-filter: blur(60px) saturate(1.1) brightness(1.1));
-  -webkit-backdrop-filter: blur(50px) saturate(1.1) brightness(1.1);
+  backdrop-filter: blur(60px) saturate(1.18) brightness(1.12);
+  -webkit-backdrop-filter: blur(50px) saturate(1.18) brightness(1.12);
 }

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -20,7 +20,7 @@ function test(lien, titre) {
     <div class="card icon-cards">
       <!-- this line is for filter icon : <div class="image" style="background-image:url(${googlefavicon(lien)});"> -->
       <div class="filter">
-          <img class="icon" src="${initialIcon}"${crossOriginAttr} onerror="this.onerror=null; this.src='${fallbackIcon}'">
+          <img class="icon" data-color-key="${lien}" src="${initialIcon}"${crossOriginAttr} onerror="this.onerror=null; this.src='${fallbackIcon}'">
         </div>
         <!--  this line is for filter icon : </div> -->
         <div class="title" title="${titre}">${smallerTitle(titre)}</div>


### PR DESCRIPTION
## Summary
- add a vibrant fallback palette for icons and skip unsafe cross-origin sampling to avoid background color failures
- attach link-based color keys to icons so backgrounds stay consistent even when icons come from remote hosts
- enhance filter/icon styling and gradient tuning for clearer, more saturated colors

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ddde0f9f88325a1b0fd18cfa3b0ca)