### PR TITLE
Improve icon color handling and add safe fallbacks

### DIFF
--- a/CSS/card.css
+++ b/CSS/card.css
@@ -46,7 +46,10 @@
   height: var(--icon-size);
   width: var(--icon-size);
   border-radius: var(--icon-radius);
-  filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.1));
+  filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.12));
+  background-color: rgba(255, 255, 255, 0.9);
+  box-sizing: border-box;
+  padding: 6px;
 }
 
 .filter {

--- a/JS/dominant-color.js
+++ b/JS/dominant-color.js
@@ -108,30 +108,58 @@ function computeDominantColor(image) {
       b: b / count,
     };
   } catch (error) {
-    console.warn("Unable to compute dominant color", error);
+    console.warn("Unable to compute dominant color", image?.currentSrc || image?.src, error);
     return null;
   }
+}
+
+function getColorKeyFromIcon(icon) {
+  const src = icon?.currentSrc || icon?.src || "";
+  try {
+    return new URL(src).hostname;
+  } catch (error) {
+    return src;
+  }
+}
+
+function vibrantFallbackColor(icon) {
+  const key = getColorKeyFromIcon(icon);
+  if (!key) return null;
+
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash << 5) - hash + key.charCodeAt(i);
+    hash |= 0;
+  }
+
+  const hue = Math.abs(hash) % 360;
+  const saturation = 0.74;
+  const lightness = 0.52;
+
+  return hslToRgb(hue, saturation, lightness);
+}
+
+function canSampleIcon(icon) {
+  if (typeof allowsCrossOriginLoading !== "function") return false;
+  return allowsCrossOriginLoading(icon?.currentSrc || icon?.src || "");
 }
 
 function applyFilterBackground(filter, color) {
   const { h, s, l } = rgbToHsl(color.r, color.g, color.b);
 
-  const balancedSaturation = Math.min(0.62, Math.max(0.28, s * 0.9 + 0.12));
-  const contrastBias = (0.5 - l) * 0.35;
-  const baseLightness = Math.min(
-    0.62,
-    Math.max(0.32, l + contrastBias + 0.08)
-  );
+  const balancedSaturation = Math.min(0.82, Math.max(0.38, s * 1.05 + 0.18));
+  const contrastBias = (0.5 - l) * 0.42;
+  const baseLightness = Math.min(0.67, Math.max(0.34, l + contrastBias + 0.06));
   const accentLightness = Math.min(
-    0.68,
-    Math.max(0.26, baseLightness + (l < 0.5 ? 0.08 : -0.08))
+    0.72,
+    Math.max(0.28, baseLightness + (l < 0.5 ? 0.1 : -0.1))
   );
 
   const baseColor = hslToRgb(h, balancedSaturation, baseLightness);
-  const accentColor = hslToRgb(h, balancedSaturation * 0.92, accentLightness);
+  const accentColor = hslToRgb(h, balancedSaturation * 0.95, accentLightness);
 
   const overlayIsDark = baseLightness > 0.5;
-  const overlayOpacity = overlayIsDark ? 0.18 : 0.12;
+  const overlayOpacity = overlayIsDark ? 0.24 : 0.16;
   const overlayTone = overlayIsDark ? "0, 0, 0" : "255, 255, 255";
 
   filter.style.background = `linear-gradient(rgba(${overlayTone}, ${overlayOpacity}), rgba(${overlayTone}, ${overlayOpacity})), linear-gradient(135deg, rgb(${baseColor.r}, ${baseColor.g}, ${baseColor.b}), rgb(${accentColor.r}, ${accentColor.g}, ${accentColor.b}))`;
@@ -143,10 +171,12 @@ function colorizeIconBackground(icon) {
   const filter = icon.closest(".filter");
   if (!filter) return;
 
-  const color = computeDominantColor(icon);
-  if (!color) return;
+  const canUseCanvas = canSampleIcon(icon);
+  const color = canUseCanvas ? computeDominantColor(icon) : null;
+  const finalColor = color ?? vibrantFallbackColor(icon);
+  if (!finalColor) return;
 
-  applyFilterBackground(filter, color);
+  applyFilterBackground(filter, finalColor);
   icon.dataset.colorized = "true";
 }
 

--- a/JS/favicons.js
+++ b/JS/favicons.js
@@ -83,7 +83,13 @@ function getFaviconPreference(address) {
 function allowsCrossOriginLoading(url) {
   if (!url) return false;
 
-  const blockedHosts = ["www.google.com"];
+  const blockedHosts = [
+    "www.google.com",
+    "t0.gstatic.com",
+    "t1.gstatic.com",
+    "t2.gstatic.com",
+    "t3.gstatic.com",
+  ];
   try {
     const hostname = new URL(url).hostname;
     return !blockedHosts.includes(hostname);


### PR DESCRIPTION
## Summary
- add cross-origin checks and hashed fallback colors to prevent canvas errors
- tune gradient generation for more vibrant yet readable card backgrounds
- pad icons with a light backdrop to improve legibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ddde0f9f88325a1b0fd18cfa3b0ca)