### PR TITLE
Fix token security and lazy image loading

### DIFF
--- a/JS/dominant-color.js
+++ b/JS/dominant-color.js
@@ -140,6 +140,11 @@ function applyFilterBackground(filter, color) {
 function colorizeIconBackground(icon) {
   if (icon.dataset.colorized) return;
 
+  // Don't try to colorize images that failed to load
+  if (!icon.complete || icon.naturalWidth === 0 || icon.naturalHeight === 0) {
+    return;
+  }
+
   const filter = icon.closest(".filter");
   if (!filter) return;
 

--- a/JS/favicons.js
+++ b/JS/favicons.js
@@ -83,10 +83,20 @@ function getFaviconPreference(address) {
 function allowsCrossOriginLoading(url) {
   if (!url) return false;
 
-  const blockedHosts = ["www.google.com"];
+  // Allow CORS for external favicon services
+  const faviconServices = [
+    "www.google.com",
+    "gstatic.com",
+    "favicon.vemetric.com",
+    "icons.duckduckgo.com",
+    "api.statvoo.com"
+  ];
+
   try {
     const hostname = new URL(url).hostname;
-    return !blockedHosts.includes(hostname);
+    // Allow CORS for known favicon services and any external domains
+    return faviconServices.some(service => hostname.includes(service)) ||
+           hostname !== window.location.hostname;
   } catch {
     return false;
   }

--- a/JS/inserthtml.js
+++ b/JS/inserthtml.js
@@ -23,9 +23,11 @@ function renderIconCard(lien, titre) {
   const { primary, fallback } = getFaviconPreference(lien);
   const initialIcon = primary ?? fallback ?? "";
   const fallbackIcon = fallback ?? "";
-  const crossOriginAttr = allowsCrossOriginLoading(initialIcon)
-    ? ' crossOrigin="anonymous"'
-    : "";
+
+  // Enable CORS for both primary and fallback if either supports it
+  const useCrossOrigin = allowsCrossOriginLoading(initialIcon) ||
+                          allowsCrossOriginLoading(fallbackIcon);
+  const crossOriginAttr = useCrossOrigin ? ' crossOrigin="anonymous"' : "";
 
   const escapedUrl = escapeHtml(lien);
   const escapedTitle = escapeHtml(titre);
@@ -36,7 +38,7 @@ function renderIconCard(lien, titre) {
   <a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">
     <div class="card icon-cards">
       <div class="filter">
-          <img class="icon" src="${escapedIcon}"${crossOriginAttr} alt="${escapedTitle}" loading="lazy" onerror="this.onerror=null; this.src='${escapedFallback}'">
+          <img class="icon" src="${escapedIcon}"${crossOriginAttr} alt="${escapedTitle}" loading="lazy" onerror="this.onerror=null; this.removeAttribute('data-colorized'); this.src='${escapedFallback}'">
         </div>
         <div class="title" title="${escapedTitle}">${escapeHtml(smallerTitle(titre))}</div>
     </div>


### PR DESCRIPTION
Changes:
- Enable CORS for all external favicon services (Google, Vemetric, etc.)
- Add validation to prevent dominant color computation on failed images
- Improve fallback handling by resetting colorization state on error
- Remove Google from CORS blocklist to allow canvas image data access

This fixes SecurityError: "canvas tainted by cross-origin data" errors and improves handling of 404 responses from favicon services.